### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const tasklist = require('tasklist');
 module.exports = launch;
 function launch (opts, cb) {
   opts = Object.assign({ poll: true, pollInterval: 3000 }, opts);
-  execFile('cmd', ['/s', '/c', 'start', 'microsoft-edge:' + opts.uri.replace(/ /g, "%20")], (err, stdout, stderr) => {
+  execFile('start', ['microsoft-edge:' + encodeURI(opts.uri)], { shell: true }, (err, stdout, stderr) => {
     if (err) return cb(err);
     const ee = new EventEmitter();
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const tasklist = require('tasklist');
 module.exports = launch;
 function launch (opts, cb) {
   opts = Object.assign({ poll: true, pollInterval: 3000 }, opts);
-  execFile('cmd', ['/s', '/c', 'start', 'microsoft-edge:' + opts.uri], (err, stdout, stderr) => {
+  execFile('cmd', ['/s', '/c', 'start', 'microsoft-edge:' + opts.uri.replace(/ /g, "%20")], (err, stdout, stderr) => {
     if (err) return cb(err);
     const ee = new EventEmitter();
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const EventEmitter = require('events');
 const tasklist = require('tasklist');
 
 module.exports = launch;
 function launch (opts, cb) {
   opts = Object.assign({ poll: true, pollInterval: 3000 }, opts);
-  exec('start microsoft-edge:' + opts.uri, (err, stdout, stderr) => {
+  execFile('start', ['microsoft-edge:' + opts.uri], (err, stdout, stderr) => {
     if (err) return cb(err);
     const ee = new EventEmitter();
 
@@ -55,7 +55,7 @@ function kill (ee) {
     if (edgeProcesses.length === 0) {
       return cb();
     } else {
-      exec('taskkill /F /IM MicrosoftEdge.exe /T', (err) => cb(err));
+      execFile('taskkill', ['/F', '/IM', 'MicrosoftEdge.exe', '/T'], (err) => cb(err));
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const tasklist = require('tasklist');
 module.exports = launch;
 function launch (opts, cb) {
   opts = Object.assign({ poll: true, pollInterval: 3000 }, opts);
-  execFile('start', ['microsoft-edge:' + opts.uri], (err, stdout, stderr) => {
+  execFile('cmd', ['/s', '/c', 'start', 'microsoft-edge:' + opts.uri], (err, stdout, stderr) => {
     if (err) return cb(err);
     const ee = new EventEmitter();
 


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-windows-edge

### ⚙️ Description *

I've replaced 2 instances of `exec` with a safer alternative (`execFile`). 

### 💻 Technical Description *

`exec()` takes its command execution value as a string, while execFile takes the command name and then the arguments as an array. I have also set the execFile option `shell` to `true`, as the executable `start` is not really an executable and requires a command line shell to function. Along with this, I made the script encode the URL before passing it to the command prompt to ensure no bad characters are passed.

### 🐛 Proof of Concept (PoC) *
Here's a quick and simple POC for this vulnerability:
```js
const edge = require('windows-edge');
edge({ uri: 'https://github.com/ > HACKED' })
```
If successful, this will create a file named HACKED in the current working directory, demonstrating the command injection vulnerability.
### 🔥 Proof of Fix (PoF) *

After running the snippet above, the following URL is opened: `https://github.com/%20%3E%20HACKED`, and no unwanted files are created, demonstrating that this vulnerability has been fixed.

### 👍 User Acceptance Testing (UAT)

I've ran the code snippet included in the README of this project and it appears to be working fine after I've made my changes.
```js
const edge = require('windows-edge');

edge({ uri: 'https://github.com/' }, (err, ps) => {
  if (err) throw err;
  ps.on('error', console.error);
  ps.on('exit', (code) => {
    // Browser exited
  });
  setTimeout(() => {
    ps.kill();
  }, 2000);
})
```
